### PR TITLE
Remove 'com.google.errorprone.annotation' entry

### DIFF
--- a/com.github.sormuras.modules/com/github/sormuras/modules/modules.properties
+++ b/com.github.sormuras.modules/com/github/sormuras/modules/modules.properties
@@ -1308,7 +1308,6 @@ com.gluonhq.richtextarea=https://repo.maven.apache.org/maven2/com/gluonhq/rich-t
 com.gluonhq.strange=https://repo.maven.apache.org/maven2/com/gluonhq/strange/0.0.12/strange-0.0.12.jar
 com.gluonhq.strangefx=https://repo.maven.apache.org/maven2/com/gluonhq/strangefx/0.0.8/strangefx-0.0.8.jar
 com.gluonhq.substrate=https://repo.maven.apache.org/maven2/com/gluonhq/substrate/0.0.61/substrate-0.0.61.jar
-com.google.errorprone.annotation=https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.26.0/error_prone_annotations-2.26.0.jar
 com.google.errorprone.annotations=https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_annotations/2.26.1/error_prone_annotations-2.26.1.jar
 com.google.j2objc.annotations=https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar
 com.googlecode.blaisemath.app=https://repo.maven.apache.org/maven2/com/googlecode/blaisemath/blaise-app/1.0.0-beta/blaise-app-1.0.0-beta.jar


### PR DESCRIPTION
This is outdated (I think it was published with the wrong name at some point). The correct name is `com.google.errorprone.annotations`, which is the entry below this one.